### PR TITLE
Migration

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -98,15 +98,33 @@ async function startServer() {
           });
     
           console.log('\n');
-        } else {
-          console.log('Order not found for the specified product ID.');
-        }
-    
-        return order;
+
+            // Push the order information to the vendor sales collection
+          const vendorSalesDocument = {
+          orderId: order._id,
+          productInfo: {
+            productId: productId,
+            quantity: order.cart_item[0].quantity, // Assuming there's only one item in the cart for simplicity
+            margin: order.cart_item[0].vendor_margin,
+          },
+          orderDate: order.payment_at,
+          };
+
+          const result = await vendorSalesCollection.insertOne(vendorSalesDocument);
+          console.log('Inserted into vendor_sales collection:', result);
+      
+
+          } else {
+            console.log('Order not found for the specified product ID.');
+          }
+          
+        
       } catch (error) {
         console.error('Error:', error);
         throw error;
       }
+
+
       
 
     }


### PR DESCRIPTION
Added a vendor_sales collection and moved each vendor's all sales to the table because:
Used to be such that to find all sales or monthly sales associated to a vendor, all orders must be traversed by the times of number of items that the vendor lists. This took too much time.
Ex: vendor lists 4k items, there are 50k sales => 50k x 4k queries.
Now given a vendorID the vendor_sales collection can be used to find all sales very quickly thanks to indexing.